### PR TITLE
提高#角色统计 优先级

### DIFF
--- a/apps/gcLog.js
+++ b/apps/gcLog.js
@@ -12,7 +12,7 @@ export class gcLog extends plugin {
       name: "抽卡记录",
       dsc: "抽卡记录数据统计",
       event: "message",
-      priority: 300,
+      priority: -114514,
       rule: [
         {
           reg: "(.*)authkey=(.*)",


### PR DESCRIPTION
防miao-fork抢，miao相应功能可以由#复刻统计 触发